### PR TITLE
basic matching and action

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,3 +69,8 @@ app.on('activate', function () {
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+
+const apri = new (require('./src/apri.js'))()
+
+// https://github.com/electron/electron/blob/master/docs/api/app.md#event-open-file-macos
+app.on('open-file', apri.handler.bind(apri))

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "electron": "~1.7.10",
     "electron-packager": "^10.1.1",
     "electron-reload": "^1.2.2",
+    "lodash": "^4.17.4",
     "trash": "^4.2.1"
   }
 }

--- a/src/apri.js
+++ b/src/apri.js
@@ -1,0 +1,31 @@
+const electron = require('electron')
+const fs = require('fs')
+const path = require('path')
+const _ = require('lodash')
+
+module.exports = class Apri {
+  constructor() {
+    this.rulesPath = path.join(electron.app.getPath('userData'), 'rules.js');
+  }
+
+  handler(event, path) {
+    let rules = this.buildRules(this.rulesPath);
+    _.each(rules, (rule, idx) => {
+      if (rule.length === 2)
+        rule = {'matcher': rule[0], 'action': rule[1]};
+      if (typeof(rule.matcher.test) === 'function' && rule.matcher.test(path)) {
+        console.info(`matched: rule[${idx}] path=${path}`);
+        rule['action'](path);
+      }
+    });
+  }
+
+  buildRules(path) {
+    if (fs.lstatSync(path).isFile()) {
+      return require(path);
+    } else {
+      console.info(`config file ${path} not found`);
+      return [];
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,6 +1101,10 @@ lodash.get@^4.0.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash@^4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"


### PR DESCRIPTION
Apri will load rules from `~/Library/Application\ Support/apri/rules.js`
Need to shift to JSON based configuration for safety.
